### PR TITLE
Updates for 0.10

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,12 +20,12 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-identity": "^1.0.0",
-    "purescript-either": "^1.0.0",
-    "purescript-st": "^1.0.0",
+    "purescript-identity": "^2.0.0",
+    "purescript-either": "^2.0.0",
+    "purescript-st": "^2.0.0",
     "purescript-partial": "^1.1.2"
   },
   "devDependencies": {
-    "purescript-console": "^1.0.0"
+    "purescript-console": "^2.0.0"
   }
 }

--- a/src/Control/Monad/Rec/Class.purs
+++ b/src/Control/Monad/Rec/Class.purs
@@ -14,7 +14,7 @@ import Control.Monad.Eff.Unsafe as U
 import Control.Monad.ST (ST(), runST, newSTRef, readSTRef, writeSTRef)
 
 import Data.Either (Either(..), fromRight)
-import Data.Identity (Identity(..), runIdentity)
+import Data.Identity (Identity(..))
 
 import Partial.Unsafe (unsafePartial)
 
@@ -82,6 +82,7 @@ tailRec f a = go (f a)
 
 instance monadRecIdentity :: MonadRec Identity where
   tailRecM f = Identity <<< tailRec (runIdentity <<< f)
+    where runIdentity (Identity x) = x
 
 instance monadRecEff :: MonadRec (Eff eff) where
   tailRecM = tailRecEff
@@ -109,7 +110,7 @@ tailRecEff f a = runST do
   unsafePartial $ fromRight <$> readSTRef r
   where
   f' :: forall h. a -> Eff (st :: ST h | eff) (Either a b)
-  f' = U.unsafeInterleaveEff <<< f
+  f' = U.unsafeCoerceEff <<< f
 
 -- | `forever` runs an action indefinitely, using the `MonadRec` instance to
 -- | ensure constant stack usage.


### PR DESCRIPTION
@garyb was the removal of `runIdentity` from purescript-identity intentional? 
