### PR TITLE
remove a space leak in tailRecEff

### DIFF
--- a/src/Control/Monad/Rec/Class.purs
+++ b/src/Control/Monad/Rec/Class.purs
@@ -112,14 +112,13 @@ instance monadRecEither :: MonadRec (Either e) where
 
 tailRecEff :: forall a b eff. (a -> Eff eff (Step a b)) -> a -> Eff eff b
 tailRecEff f a = runST do
-  e <- f' a
-  r <- newSTRef e
+  r <- newSTRef =<< f' a
   untilE do
-    e' <- readSTRef r
-    case e' of
+    e <- readSTRef r
+    case e of
       Loop a' -> do
-        e'' <- f' a'
-        _ <- writeSTRef r e''
+        e' <- f' a'
+        _ <- writeSTRef r e'
         pure false
       Done b -> pure true
   fromDone <$> readSTRef r


### PR DESCRIPTION
`tailRecEff` was holding a reference to the result of `f' a`.

Normally, this wouldn't matter, but in this case we are about to enter a loop that may last a long time, so it is better to let the GC clean up the result of `f' a`.