### PR TITLE
Add convenience functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+- Added `tailRec2`, `tailRec3`, `loop2`, `loop3` convenience functions (#40 by @rhendric)
 
 Bugfixes:
 

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -2,7 +2,7 @@ module Test.Main where
 
 import Prelude
 
-import Control.Monad.Rec.Class (Step(..), tailRec, tailRecM, tailRecM2, untilJust, whileJust)
+import Control.Monad.Rec.Class (Step(..), tailRec, tailRec2, tailRecM, tailRecM2, untilJust, whileJust, loop2)
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
@@ -18,6 +18,12 @@ triangle = tailRecM2 f 0
   f acc n = do
     log $ "Accumulator: " <> show acc
     pure (Loop { a: acc + n, b: n - 1 })
+
+trianglePure :: Int -> Int
+trianglePure = tailRec2 f 0
+  where
+  f acc 0 = Done acc
+  f acc n = loop2 (acc + n) (n - 1)
 
 loop :: Int -> Effect Unit
 loop n = tailRecM go n
@@ -49,6 +55,9 @@ main :: Effect Unit
 main = do
   test "triangle" 55 do
     triangle 10
+
+  test "trianglePure" 55 do
+    pure $ trianglePure 10
   
   test "mutual" false do
     pure $ mutual 1000001


### PR DESCRIPTION
`tailRec2` and `tailRec3` complete the `tailRec` and `tailRecM` matrix,
and `loop2` and `loop3` are new conveniences for both `tailRec2/3` and
`tailRecM2/3` that better abstract the consumer away from the details of
the `a`, `b`, `c` record labels we use in those functions.

**Description of the change**

Submitting this for discussion in preparation for doing something about purescript/purescript#4289. All of these new functions are optional for that proposal, but before we go hard on promoting `purescript-tailrec` as the best way to ensure that one's stack-hungry functions execute safely, I think we should address these rough edges, and standardizing on them will make it possible to optimize them out.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
